### PR TITLE
Update run lobby script - remove derby classpath

### DIFF
--- a/files/lobby/run_lobby
+++ b/files/lobby/run_lobby
@@ -4,4 +4,4 @@ PORT=${1:-'3304'}
 RAM=${2:-'256M'}
 
 cd $(dirname $0)
-java -server -Xmx$RAM -Xms$RAM -classpath bin/triplea.jar:lib/derby-10.10.1.1.jar -Dtriplea.lobby.port=$PORT games.strategy.engine.lobby.server.LobbyServer
+java -server -Xmx$RAM -Xms$RAM -classpath bin/triplea.jar -Dtriplea.lobby.port=$PORT games.strategy.engine.lobby.server.LobbyServer


### PR DESCRIPTION
We've recently updated to not use derby at all. We no longer use derby, don't need
it on the classpath anymore.

https://github.com/triplea-game/triplea/pull/2343